### PR TITLE
Keep "recently" frontend state, remove `ContentPage.getDerivedStateFromProps` (#644)

### DIFF
--- a/HEROKU.md
+++ b/HEROKU.md
@@ -20,6 +20,8 @@ Click the Heroku button and follow the instructions below:
 6. Fill out the `JWK_BASE_URL` field with the URL to your LMS. The default value works for instructure hosted instances of Canvas, but will need to be modified if your JWK configuration is hosted at a different domain than `iss`.
 7. Click the Deploy button and wait for the process to complete.
 
+The above deploy uses the Heroku Postgres Mini plan by default. Please check `https://elements.heroku.com/addons/heroku-postgresql` for Heroku Postgresql plan details. You can upgrade Postgresql plan inside Heroku UI later.
+
 ### Step 2: Database Migration and Setup
 Next we need to set up the database and insert our institution in to the appropriate table.
 1. Click "Manage App" or go to `https://dashboard.heroku.com/apps/yourapp`. (Replace 'yourapp' with the name you gave in Step 1.2.)

--- a/app.json
+++ b/app.json
@@ -36,7 +36,7 @@
 	  }
 	},
 	"addons": [
-	  "heroku-postgresql:basic"
+	  "heroku-postgresql:mini"
 	],
 	"buildpacks": [
 	  {

--- a/app.json
+++ b/app.json
@@ -36,7 +36,7 @@
 	  }
 	},
 	"addons": [
-	  "heroku-postgresql:hobby-basic"
+	  "heroku-postgresql:basic"
 	],
 	"buildpacks": [
 	  {

--- a/assets/js/Components/App.js
+++ b/assets/js/Components/App.js
@@ -216,14 +216,19 @@ class App extends React.Component {
     this.messages = [];
   }
 
-  handleIssueSave(newIssue) {
-    const newReport = { ...this.state.report };
+  handleIssueSave(newIssue, newReport) {
+    const oldReport = this.state.report;
+    const report = { ...oldReport, ...newReport };
 
-    if (newReport && Array.isArray(newReport.issues)) {
-      newReport.issues = newReport.issues.map(issue => (issue.id == newIssue.id) ? newIssue : issue);
-    }
+    // Combine issues with frontend state
+    report.issues = report.issues.map((issue) => {
+      if (issue.id === newIssue.id) return newIssue
 
-    this.setState({ report: newReport });
+      const oldIssue = oldReport.issues.find(oldReportIssue => oldReportIssue.id === issue.id);
+      return oldIssue !== undefined ? { ...oldIssue, ...issue } : issue;
+    });
+
+    this.setState({ report });
   }
 
   handleFileSave(newFile, newReport) {

--- a/assets/js/Components/App.js
+++ b/assets/js/Components/App.js
@@ -216,15 +216,14 @@ class App extends React.Component {
     this.messages = [];
   }
 
-  handleIssueSave(newIssue, newReport) {
-    let { report } = this.state
-    report = {...report, ...newReport}
+  handleIssueSave(newIssue) {
+    const newReport = { ...this.state.report };
 
-    if (report && Array.isArray(report.issues)) {
-      report.issues = report.issues.map(issue => (issue.id == newIssue.id) ? newIssue : issue)
+    if (newReport && Array.isArray(newReport.issues)) {
+      newReport.issues = newReport.issues.map(issue => (issue.id == newIssue.id) ? newIssue : issue);
     }
 
-    this.setState({ report })
+    this.setState({ report: newReport });
   }
 
   handleFileSave(newFile, newReport) {

--- a/assets/js/Components/ContentPage.js
+++ b/assets/js/Components/ContentPage.js
@@ -79,7 +79,7 @@ class ContentPage extends React.Component {
 
   static getDerivedStateFromProps(props, state) {
     const stateActiveIssue = state.activeIssue
-    const propsActiveIssue = stateActiveIssue && props.report.issues[stateActiveIssue.id]
+    const propsActiveIssue = stateActiveIssue && props.report.issues.find(x => x.id === stateActiveIssue.id);
     if(propsActiveIssue && propsActiveIssue.status !== stateActiveIssue.status) {
       return {
         activeIssue: propsActiveIssue

--- a/assets/js/Components/ContentPage.js
+++ b/assets/js/Components/ContentPage.js
@@ -102,9 +102,17 @@ class ContentPage extends React.Component {
   }
 
   handleCloseButton = () => {
+    const newReport = { ...this.props.report };
+    newReport.issues = newReport.issues.map(issue => {
+      issue.recentlyResolved = false;
+      issue.recentlyUpdated = false;
+      return issue;
+    });
+
     this.setState({
+      report: newReport,
       modalOpen: false
-    })
+    });
   }
 
   handleTrayToggle = (e, val) => {

--- a/assets/js/Components/ContentPage.js
+++ b/assets/js/Components/ContentPage.js
@@ -77,17 +77,6 @@ class ContentPage extends React.Component {
     }
   }
 
-  static getDerivedStateFromProps(props, state) {
-    const stateActiveIssue = state.activeIssue
-    const propsActiveIssue = stateActiveIssue && props.report.issues.find(x => x.id === stateActiveIssue.id);
-    if(propsActiveIssue && propsActiveIssue.status !== stateActiveIssue.status) {
-      return {
-        activeIssue: propsActiveIssue
-      }
-    }
-    return null
-  }
-
   handleSearchTerm = (e, val) => {
     this.setState({searchTerm: val, filteredIssues: [], tableSettings: Object.assign({}, this.state.tableSettings, {pageNum: 0})});
   }

--- a/assets/js/Components/UfixitModal.js
+++ b/assets/js/Components/UfixitModal.js
@@ -355,8 +355,7 @@ class UfixitModal extends React.Component {
           // update activeIssue
           issue.pending = false
           this.props.handleActiveIssue(issue)
-        }
-        else {
+        } else {
           // set messages 
           response.messages.forEach((msg) => this.addMessage(msg))
 
@@ -371,11 +370,9 @@ class UfixitModal extends React.Component {
               .then((res) => {
                 // update activeIssue
                 this.props.handleActiveIssue(newIssue)
-                
-                this.props.handleIssueSave(newIssue, res.data)
+                this.props.handleIssueSave(newIssue);
               })
-          }
-          else {
+          } else {
             issue.pending = false
             this.props.handleActiveIssue(issue)
           }

--- a/assets/js/Components/UfixitModal.js
+++ b/assets/js/Components/UfixitModal.js
@@ -370,7 +370,7 @@ class UfixitModal extends React.Component {
               .then((res) => {
                 // update activeIssue
                 this.props.handleActiveIssue(newIssue)
-                this.props.handleIssueSave(newIssue);
+                this.props.handleIssueSave(newIssue, res.data);
               })
           } else {
             issue.pending = false

--- a/yarn.lock
+++ b/yarn.lock
@@ -7755,9 +7755,9 @@ json3@^3.3.3:
   integrity sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA==
 
 json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
+  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
@@ -8181,9 +8181,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
-  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
+  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR aims to resolve UCF's issue 644.

Explanation (or an attempt at one):

This PR tries to accomplish two things:

1) Resolve the strange navigation behavior documented in issue 644 by removing the `ContentPage.getDerivedStateFromProps`. @jonespm started fixing this by correcting an error in logic treating IDs as indexes; I just ended up replacing some of the logic here with the change for 2.

2) Modify `App.handleIssueSave` and `ContentPage.handleCloseButton` so that for all active issues fixed or resolved while the `UFixitModal` is open remain in the modal until it's closed manually. This is accomplished by combining the frontend and backend versions of each issue, with preference to values from the the backend version. Because `recentlyResolved` and `recentlyUpdated` aren't set in the backend, they should still be present in the resulting report. Note that (I believe) this keep-in-the-modal logic only applies to active issues; thus, issues filtered as resolved may still disappear jarringly if the user un-resolves them.

I'd be very grateful for testing and comments; this may not be complete yet and there could be bugs to resolve or simplifications to be made. This likely won't be merged here (and maybe even not in the UCF repo if a fix already exists), but I figured I'd document my work and solicit feedback in case we need to contribute.